### PR TITLE
Integrate RunPod Serverless support (v2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image from RunPod with PyTorch, Python 3.11, and CUDA 12.1.1
-FROM runpod/pytorch:2.3.0-py3.11-cuda12.1.1-devel-ubuntu22.04
+FROM runpod/pytorch:2.2.1-py3.11-cuda12.1.1-devel-ubuntu22.04
 
 # Set the working directory
 WORKDIR /app

--- a/predict.py
+++ b/predict.py
@@ -64,21 +64,11 @@ class FluxDevKontextPredictor(BasePredictor):
 
         # Initialize safety checker
         self.safety_checker = SafetyChecker()
-        print("Compiling model with torch.compile...")
-        start_time = time.time()
-        self.predict(
-            prompt="Make the hair blue",
-            input_image=Path("lady.png"),
-            aspect_ratio="1:1",
-            num_inference_steps=30,
-            guidance=2.5,
-            seed=42,
-            output_format="png",
-            output_quality=100,
-            disable_safety_checker=True,
-            go_fast=True,
-        )
-        print(f"Compiled in {time.time() - start_time} seconds")
+        print("Model setup complete. The model was compiled with torch.compile earlier.")
+        # Removed the warm-up self.predict() call as it expects a local Path
+        # and the primary predict function now uses input_image_url.
+        # The core model (self.model) is already compiled by torch.compile.
+        # The full pipeline JIT for a specific input will happen on the first actual call.
         print("FluxDevKontextPredictor setup complete")
 
 


### PR DESCRIPTION
- Update Dockerfile base image to a verified RunPod tag.
- Remove problematic warm-up call from predict.py setup method.
- Add rp_handler.py as the RunPod entry point.
- Modify predict.py to accept image URLs instead of local paths, including downloading the image and handling temporary files.
- Create a Dockerfile based on cog.yaml, using a RunPod PyTorch base image, installing dependencies, and setting up the environment.
- Create requirements.txt from cog.yaml python_packages.
- Ensure weights.py functions correctly within the Docker environment.